### PR TITLE
fix go sdk link

### DIFF
--- a/modules/project-docs/pages/get-involved.adoc
+++ b/modules/project-docs/pages/get-involved.adoc
@@ -4,7 +4,7 @@
 == Contributing
 
 Couchbase welcomes community contributions to the Go SDK.
-The https://github.com/couchbase/gocbt[Go SDK source code^] is available on GitHub.
+The https://github.com/couchbase/gocb[Go SDK source code^] is available on GitHub.
 Please see the https://github.com/couchbase/gocb/blob/master/CONTRIBUTING.md[CONTRIBUTING^] file for further information.
 
 include::6.5@sdk:shared:partial$contrib.adoc[tag=contrib]


### PR DESCRIPTION
On this page the link of GO SDK was wrong and we got 404 which I noticed it refers to a wrong link